### PR TITLE
Fix dictionary unpacking

### DIFF
--- a/dynamic_yaml/__init__.py
+++ b/dynamic_yaml/__init__.py
@@ -27,5 +27,5 @@ add_wrappers(DynamicYamlLoader)
 
 def load(stream, loader=DynamicYamlLoader, recursive=False):
     result = yaml.load(stream, Loader=loader)
-    result.set_as_root(recursive=recursive)
+    result._set_as_root(recursive=recursive)
     return result

--- a/dynamic_yaml/yaml_wrappers.py
+++ b/dynamic_yaml/yaml_wrappers.py
@@ -76,7 +76,7 @@ class YamlList(DynamicYamlObject, MutableSequence):
     def __init__(self, *args, **kwargs):
         super().__init__()
         super().__setattr__('_collection', list(*args, **kwargs))
-        super().__setattr__('_root', {YamlList.ROOT_NAME: self})
+        super().__setattr__('_root', YamlDict([(YamlList.ROOT_NAME, self)]))
 
     def insert(self, index: int, object):
         super().__getattribute__('_collection').insert(index, object)

--- a/tests/test_dynamic_yaml.py
+++ b/tests/test_dynamic_yaml.py
@@ -4,7 +4,18 @@ from unittest import TestCase, main
 from dynamic_yaml import load
 
 
-class TestYamlDict(TestCase):
+class TestDynamicYaml(TestCase):
+    def test_list(self):
+        config = '''
+        - a
+        - b
+        - c
+        '''
+        res = load(config)
+        self.assertEqual('a', res[0])
+        self.assertEqual('b', res[1])
+        self.assertEqual('c', res[2])
+
     def test_dict(self):
         config = '''
         a: 1

--- a/tests/test_dynamic_yaml.py
+++ b/tests/test_dynamic_yaml.py
@@ -16,6 +16,17 @@ class TestDynamicYaml(TestCase):
         self.assertEqual('b', res[1])
         self.assertEqual('c', res[2])
 
+    def test_list_resolution(self):
+        config = '''
+        - a
+        - b
+        - '{root[0]}'
+        '''
+        res = load(config)
+        self.assertEqual('a', res[0])
+        self.assertEqual('b', res[1])
+        self.assertEqual('a', res[2])
+
     def test_dict(self):
         config = '''
         a: 1

--- a/tests/test_yaml_dict.py
+++ b/tests/test_yaml_dict.py
@@ -12,7 +12,9 @@ class TestYamlDict(TestCase):
         c: a
         '''
         res = load(config)
-        self.assertDictEqual({'a': 1, 'b': 2, 'c': 'a'}, res)
+        self.assertEqual(1, res.a)
+        self.assertEqual(2, res.b)
+        self.assertEqual('a', res.c)
     
     def test_nested_dict(self):
         config = '''
@@ -23,7 +25,10 @@ class TestYamlDict(TestCase):
           e: 'a'
         '''
         res = load(config)
-        self.assertDictEqual({'a': 1, 'b': {'c': 3, 'd': 4, 'e': 'a'}}, res)
+        self.assertEqual(1, res.a)
+        self.assertEqual(3, res.b.c)
+        self.assertEqual(4, res.b.d)
+        self.assertEqual('a', res.b.e)
 
     def test_deeply_nested_dict(self):
         config = '''
@@ -37,7 +42,11 @@ class TestYamlDict(TestCase):
               h: 5
         '''
         res = load(config)
-        self.assertDictEqual({'a': 1, 'b': {'c': 2, 'd': 3, 'e': {'f': 4, 'g': {'h': 5}}}}, res)
+        self.assertEqual(1, res.a)
+        self.assertEqual(2, res.b.c)
+        self.assertEqual(3, res.b.d)
+        self.assertEqual(4, res.b.e.f)
+        self.assertEqual(5, res.b.e.g.h)
 
     def test_resolve_simple(self):
         config = '''
@@ -144,12 +153,27 @@ class TestYamlDict(TestCase):
     def test_recursive(self):
         config = '''
         prefix: /opt/ml
-        input_path: "{prefix}/input"
+        input_path: '{prefix}/input'
         training_data_path: '{input_path}/data/training'
         '''
 
         res = load(config, recursive=True)
+        self.assertEqual('/opt/ml/input', res.input_path)
         self.assertEqual('/opt/ml/input/data/training', res.training_data_path)
+
+    def test_keyword_args(self):
+        config = '''
+        prefix: /opt/ml
+        input_path: '{prefix}/input'
+        training_data_path: '{input_path}/data/training'
+        '''
+
+        def inner_test(input_path, training_data_path, **kwargs):
+            self.assertEqual('/opt/ml/input', input_path)
+            self.assertEqual('/opt/ml/input/data/training', training_data_path)
+
+        res = load(config, recursive=True)
+        inner_test(**res)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #5

Major changes:
* Refactored out common code of `YamlDict` and `YamlList` to `DynamicYamlObject`
* Inherit `YamlDict` from `MutableMapping` and implement `__iter__` to fix unpacking bug in `YamlDict`
* Inherit `YamlList` from `MutableSequence` and implement `__iter__` to fix unpacking bug in `YamlList`
* Fix list resolution

Minor changes:
* Added test if list is at the root
* Added test for list resolution
* Added unpacking test